### PR TITLE
Update mcversion-1.16.5.properties

### DIFF
--- a/mcversion-1.16.5.properties
+++ b/mcversion-1.16.5.properties
@@ -1,14 +1,11 @@
 minecraft_version=1.16.5
-yarn_mappings=1.16.5+build.4
-loader_version=0.11.1
+yarn_mappings=1.16.5+build.5
+loader_version=0.11.2
 
 #Fabric api
-fabric_version=0.30.0+1.16
-fabric_versiononly=0.30.0
+fabric_version=0.31.0+1.16
+fabric_versiononly=0.31.0
 
-// CF has 1.16.5 but newest maven version seems to be 1.15.0 -- 20210205
-// modmenu_version=1.16.5
-modmenu_version=1.15.0+build.1
+modmenu_version=1.16.8
 
-ccc_version=1.0.1+1.16-rc1
 gbfabrictools_version=1.3.2+1.16.4


### PR DESCRIPTION
Add the jitpack.io maven repo and you can get the latest Mod Menu version. Got rid of CCC as it has been deprecated in favour of the Fabric Commands API v1, first present in 0.31.0. See gbl/AntiGhost#15 as well.