### PR TITLE
Adding properties file for Minecraft 1.20.1

### DIFF
--- a/mcversion-1.20.1.properties
+++ b/mcversion-1.20.1.properties
@@ -1,0 +1,12 @@
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.1
+loader_version=0.14.21
+
+#Fabric api
+fabric_version=0.83.0+1.20.1
+fabric_versiononly=0.83.0
+
+modmenu_version=7.0.1
+
+gbfabrictools_version=1.3.4+1.19.3
+crowdintranslate_version=1.4+1.19.3


### PR DESCRIPTION
Upped versions of minecraft, yarn, loader, fabric and modmenu to latest build Left the gbfabrictools version and crowdintranslate to same

Note: gbfabrictools gui is broken for 1.20. It needs a massive rewrite DrawableHelper has been renamed to DrawContext and there were a lot of methods which were overridden but don't exist in the parent anymore